### PR TITLE
Add referenceSystemInfo to ISO19119 metadata generation for INSPIRE SDS

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -46,7 +46,7 @@ linters:
     - gocritic                  # Provides diagnostics that check for bugs, performance and style issues.
     - goheader                  # Check if file header matches to pattern.
     - gomoddirectives           # Manage the use of 'replace', 'retract', and 'excludes' directives in go.mod.
-    - gomodguard                # Allow and blocklist linter for direct Go module dependencies. This is different from depguard where there are different block types for example version constraints and module recommendations.
+    - gomodguard_v2             # Allow and blocklist linter for direct Go module dependencies. This is different from depguard where there are different block types for example version constraints and module recommendations.
     - goprintffuncname          # Checks that printf-like functions are named with `f` at the end.
     - gosec                     # Inspects source code for security problems.
     - gosmopolitan              # Report certain i18n/l10n anti-patterns in your Go codebase.
@@ -105,6 +105,7 @@ linters:
           - dupl          # Detects duplicate fragments of code.
           - funlen        # Checks for long functions.
           - gosec         # Inspects source code for security problems.
+          - goconst       # Finds repeated strings that could be replaced by a constant.
           - nestif        # Reports deeply nested if statements.
           - paralleltest  # Detects missing usage of t.Parallel() method in your Go test.
           - testpackage   # Linter that makes you use a separate _test package.

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -46,7 +46,7 @@ linters:
     - gocritic                  # Provides diagnostics that check for bugs, performance and style issues.
     - goheader                  # Check if file header matches to pattern.
     - gomoddirectives           # Manage the use of 'replace', 'retract', and 'excludes' directives in go.mod.
-    - gomodguard_v2             # Allow and blocklist linter for direct Go module dependencies. This is different from depguard where there are different block types for example version constraints and module recommendations.
+    - gomodguard                # Allow and blocklist linter for direct Go module dependencies. This is different from depguard where there are different block types for example version constraints and module recommendations.
     - goprintffuncname          # Checks that printf-like functions are named with `f` at the end.
     - gosec                     # Inspects source code for security problems.
     - gosmopolitan              # Report certain i18n/l10n anti-patterns in your Go codebase.

--- a/examples/service_specifics/example.json
+++ b/examples/service_specifics/example.json
@@ -44,6 +44,12 @@
         "AA",
         "BB",
         "CCC"
+      ],
+      "referenceSystemIdentifiers": [
+        "EPSG:4326",
+        "EPSG:28992",
+        "EPSG:3857",
+        "EPSG:4258"
       ]
     },
     {

--- a/examples/service_specifics/example.yaml
+++ b/examples/service_specifics/example.yaml
@@ -35,6 +35,11 @@ services:
       - "AA"
       - "BB"
       - "CCC"
+    referenceSystemIdentifiers:
+      - "EPSG:4326"
+      - "EPSG:28992"
+      - "EPSG:3857"
+      - "EPSG:4258"
   - type: wms
     id: "00000000-0000-0000-0000-000000000002"
     accessPoint: "https://example.nl/example/wms?request=GetCapabilities&service=WMS"

--- a/pkg/generator/iso19119/generator.go
+++ b/pkg/generator/iso19119/generator.go
@@ -3,6 +3,7 @@ package iso19119
 
 import (
 	"fmt"
+	"log/slog"
 	"net/url"
 	"strings"
 
@@ -142,7 +143,7 @@ func (g *Generator) generateMetadataEntries() error {
 	return nil
 }
 
-func (g *Generator) setGeneralInfo() error {
+func (g *Generator) setGeneralInfo() error { //nolint:funlen
 	entry, err := g.CurrentEntry()
 	if err != nil {
 		return err
@@ -245,6 +246,39 @@ func (g *Generator) setGeneralInfo() error {
 			// https://docs.geostandaarden.nl/md/mdprofiel-iso19119/#metadatastandaard-versie
 			CharacterString: "Nederlands metadata profiel op ISO 19119 voor services 2.1.0",
 		},
+	}
+
+	if config.isInspireSDS() {
+		entry.Metadata.ReferenceSystemInfos = []iso1911x.ReferenceSystemInfo{}
+
+		for _, rsIdentifier := range config.ReferenceSystemIdentifiers {
+			referenceSystem, ok := g.Codelist.GetReferenceSystemByEPSGCode(rsIdentifier)
+			if !ok {
+				slog.Warn("no reference system found for EPSG code", "rsIdentifier", rsIdentifier)
+				// TODO Add missing reference systems to codelist
+				continue
+			}
+
+			referenceSystemInfo := iso1911x.ReferenceSystemInfo{
+				MDReferenceSystem: iso1911x.MDReferenceSystem{
+					ReferenceSystemIdentifier: iso1911x.ReferenceSystemIdentifier{
+						RSIdentifier: iso1911x.RSIdentifier{
+							Code: iso1911x.Code{
+								Anchor: iso1911x.AnchorTag{
+									Href:  referenceSystem.URI,
+									Value: referenceSystem.Name,
+								},
+							},
+						},
+					},
+				},
+			}
+
+			entry.Metadata.ReferenceSystemInfos = append(
+				entry.Metadata.ReferenceSystemInfos,
+				referenceSystemInfo,
+			)
+		}
 	}
 
 	return nil

--- a/pkg/generator/iso19119/service_specifics.go
+++ b/pkg/generator/iso19119/service_specifics.go
@@ -232,7 +232,7 @@ func (s *ServiceSpecifics) Validate() error {
 
 // Validate the ServiceSpecifics on service level.
 //
-//nolint:cyclop,gocognit
+//nolint:cyclop,gocognit,funlen
 func (sc ServiceConfig) Validate() error {
 	var errors []string
 

--- a/pkg/generator/iso19119/service_specifics.go
+++ b/pkg/generator/iso19119/service_specifics.go
@@ -31,10 +31,11 @@ type GlobalConfig struct {
 type ServiceConfig struct {
 	OverrideableFields `json:",inline,omitempty" yaml:",inline,omitempty"`
 
-	Type               string              `json:"type,omitempty"               yaml:"type,omitempty"`
-	ID                 string              `json:"id,omitempty"                 yaml:"id,omitempty"`
-	AccessPoint        string              `json:"accessPoint,omitempty"        yaml:"accessPoint,omitempty"`
-	ServiceInspireType *InspireServiceType `json:"serviceInspireType,omitempty" yaml:"serviceInspireType,omitempty"`
+	Type                       string              `json:"type,omitempty"                       yaml:"type,omitempty"`
+	ID                         string              `json:"id,omitempty"                         yaml:"id,omitempty"`
+	AccessPoint                string              `json:"accessPoint,omitempty"                yaml:"accessPoint,omitempty"`
+	ServiceInspireType         *InspireServiceType `json:"serviceInspireType,omitempty"         yaml:"serviceInspireType,omitempty"`
+	ReferenceSystemIdentifiers []string            `json:"referenceSystemIdentifiers,omitempty" yaml:"referenceSystemIdentifiers,omitempty"`
 
 	// Pointer to globals
 	Globals *GlobalConfig `json:"globals,omitempty" yaml:"globals,omitempty"`
@@ -326,6 +327,10 @@ func (sc ServiceConfig) Validate() error {
 		len(sc.GetInspireThemes()) != 1 {
 		errors = append(errors,
 			"exactly 1 inspireTheme must be set if InspireDatasetType is 'harmonised'")
+	}
+
+	if sc.isInspireSDS() && len(sc.ReferenceSystemIdentifiers) == 0 {
+		errors = append(errors, "SDS services must have at least one referenceSystemIdentifier")
 	}
 
 	if len(errors) > 0 {

--- a/pkg/generator/iso19119/service_specifics.go
+++ b/pkg/generator/iso19119/service_specifics.go
@@ -232,7 +232,7 @@ func (s *ServiceSpecifics) Validate() error {
 
 // Validate the ServiceSpecifics on service level.
 //
-//nolint:cyclop
+//nolint:cyclop,gocognit
 func (sc ServiceConfig) Validate() error {
 	var errors []string
 

--- a/pkg/generator/iso19119/service_specifics_test.go
+++ b/pkg/generator/iso19119/service_specifics_test.go
@@ -59,6 +59,13 @@ func TestServiceSpecificsLoadFromYAMLAndValidate(t *testing.T) {
 				"inspireThemes are required when inspireType is set",
 			},
 		},
+		{
+			filename:      "invalid_inspire_sds_without_referencesystem.yaml",
+			expectedValid: false,
+			expectedValidationErrors: []string{
+				"SDS services must have at least one referenceSystemIdentifier",
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/pkg/generator/iso19119/testdata/expected/inspire_asis_wfs.xml
+++ b/pkg/generator/iso19119/testdata/expected/inspire_asis_wfs.xml
@@ -51,6 +51,50 @@
   <gmd:metadataStandardVersion>
     <gco:CharacterString>Nederlands metadata profiel op ISO 19119 voor services 2.1.0</gco:CharacterString>
   </gmd:metadataStandardVersion>
+  <gmd:referenceSystemInfo>
+    <gmd:MD_ReferenceSystem>
+      <gmd:referenceSystemIdentifier>
+        <gmd:RS_Identifier>
+          <gmd:code>
+            <gmx:Anchor xmlns:gmx="http://www.isotc211.org/2005/gmx" xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="https://www.opengis.net/def/crs/EPSG/0/4326">WGS84</gmx:Anchor>
+          </gmd:code>
+        </gmd:RS_Identifier>
+      </gmd:referenceSystemIdentifier>
+    </gmd:MD_ReferenceSystem>
+  </gmd:referenceSystemInfo>
+  <gmd:referenceSystemInfo>
+    <gmd:MD_ReferenceSystem>
+      <gmd:referenceSystemIdentifier>
+        <gmd:RS_Identifier>
+          <gmd:code>
+            <gmx:Anchor xmlns:gmx="http://www.isotc211.org/2005/gmx" xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://www.opengis.net/def/crs/EPSG/0/28992">Amersfoort / RD New</gmx:Anchor>
+          </gmd:code>
+        </gmd:RS_Identifier>
+      </gmd:referenceSystemIdentifier>
+    </gmd:MD_ReferenceSystem>
+  </gmd:referenceSystemInfo>
+  <gmd:referenceSystemInfo>
+    <gmd:MD_ReferenceSystem>
+      <gmd:referenceSystemIdentifier>
+        <gmd:RS_Identifier>
+          <gmd:code>
+            <gmx:Anchor xmlns:gmx="http://www.isotc211.org/2005/gmx" xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="https://www.opengis.net/def/crs/EPSG/0/3857">WGS84 / Pseudo-Mercator</gmx:Anchor>
+          </gmd:code>
+        </gmd:RS_Identifier>
+      </gmd:referenceSystemIdentifier>
+    </gmd:MD_ReferenceSystem>
+  </gmd:referenceSystemInfo>
+  <gmd:referenceSystemInfo>
+    <gmd:MD_ReferenceSystem>
+      <gmd:referenceSystemIdentifier>
+        <gmd:RS_Identifier>
+          <gmd:code>
+            <gmx:Anchor xlink:href="http://www.opengis.net/def/crs/EPSG/0/4258">ETRS89</gmx:Anchor>
+          </gmd:code>
+        </gmd:RS_Identifier>
+      </gmd:referenceSystemIdentifier>
+    </gmd:MD_ReferenceSystem>
+  </gmd:referenceSystemInfo>
   <gmd:identificationInfo>
     <srv:SV_ServiceIdentification>
       <gmd:citation>

--- a/pkg/generator/iso19119/testdata/expected/inspire_harmonised_wfs.xml
+++ b/pkg/generator/iso19119/testdata/expected/inspire_harmonised_wfs.xml
@@ -51,6 +51,50 @@
   <gmd:metadataStandardVersion>
     <gco:CharacterString>Nederlands metadata profiel op ISO 19119 voor services 2.1.0</gco:CharacterString>
   </gmd:metadataStandardVersion>
+  <gmd:referenceSystemInfo>
+    <gmd:MD_ReferenceSystem>
+      <gmd:referenceSystemIdentifier>
+        <gmd:RS_Identifier>
+          <gmd:code>
+            <gmx:Anchor xmlns:gmx="http://www.isotc211.org/2005/gmx" xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="https://www.opengis.net/def/crs/EPSG/0/4326">WGS84</gmx:Anchor>
+          </gmd:code>
+        </gmd:RS_Identifier>
+      </gmd:referenceSystemIdentifier>
+    </gmd:MD_ReferenceSystem>
+  </gmd:referenceSystemInfo>
+  <gmd:referenceSystemInfo>
+    <gmd:MD_ReferenceSystem>
+      <gmd:referenceSystemIdentifier>
+        <gmd:RS_Identifier>
+          <gmd:code>
+            <gmx:Anchor xmlns:gmx="http://www.isotc211.org/2005/gmx" xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://www.opengis.net/def/crs/EPSG/0/28992">Amersfoort / RD New</gmx:Anchor>
+          </gmd:code>
+        </gmd:RS_Identifier>
+      </gmd:referenceSystemIdentifier>
+    </gmd:MD_ReferenceSystem>
+  </gmd:referenceSystemInfo>
+  <gmd:referenceSystemInfo>
+    <gmd:MD_ReferenceSystem>
+      <gmd:referenceSystemIdentifier>
+        <gmd:RS_Identifier>
+          <gmd:code>
+            <gmx:Anchor xmlns:gmx="http://www.isotc211.org/2005/gmx" xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="https://www.opengis.net/def/crs/EPSG/0/3857">WGS84 / Pseudo-Mercator</gmx:Anchor>
+          </gmd:code>
+        </gmd:RS_Identifier>
+      </gmd:referenceSystemIdentifier>
+    </gmd:MD_ReferenceSystem>
+  </gmd:referenceSystemInfo>
+  <gmd:referenceSystemInfo>
+    <gmd:MD_ReferenceSystem>
+      <gmd:referenceSystemIdentifier>
+        <gmd:RS_Identifier>
+          <gmd:code>
+            <gmx:Anchor xlink:href="http://www.opengis.net/def/crs/EPSG/0/4258">ETRS89</gmx:Anchor>
+          </gmd:code>
+        </gmd:RS_Identifier>
+      </gmd:referenceSystemIdentifier>
+    </gmd:MD_ReferenceSystem>
+  </gmd:referenceSystemInfo>
   <gmd:identificationInfo>
     <srv:SV_ServiceIdentification>
       <gmd:citation>

--- a/pkg/generator/iso19119/testdata/expected/inspire_hvd_complex_oaf_interoperable.xml
+++ b/pkg/generator/iso19119/testdata/expected/inspire_hvd_complex_oaf_interoperable.xml
@@ -51,6 +51,50 @@
   <gmd:metadataStandardVersion>
     <gco:CharacterString>Nederlands metadata profiel op ISO 19119 voor services 2.1.0</gco:CharacterString>
   </gmd:metadataStandardVersion>
+  <gmd:referenceSystemInfo>
+    <gmd:MD_ReferenceSystem>
+      <gmd:referenceSystemIdentifier>
+        <gmd:RS_Identifier>
+          <gmd:code>
+            <gmx:Anchor xmlns:gmx="http://www.isotc211.org/2005/gmx" xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="https://www.opengis.net/def/crs/EPSG/0/4326">WGS84</gmx:Anchor>
+          </gmd:code>
+        </gmd:RS_Identifier>
+      </gmd:referenceSystemIdentifier>
+    </gmd:MD_ReferenceSystem>
+  </gmd:referenceSystemInfo>
+  <gmd:referenceSystemInfo>
+    <gmd:MD_ReferenceSystem>
+      <gmd:referenceSystemIdentifier>
+        <gmd:RS_Identifier>
+          <gmd:code>
+            <gmx:Anchor xmlns:gmx="http://www.isotc211.org/2005/gmx" xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://www.opengis.net/def/crs/EPSG/0/28992">Amersfoort / RD New</gmx:Anchor>
+          </gmd:code>
+        </gmd:RS_Identifier>
+      </gmd:referenceSystemIdentifier>
+    </gmd:MD_ReferenceSystem>
+  </gmd:referenceSystemInfo>
+  <gmd:referenceSystemInfo>
+    <gmd:MD_ReferenceSystem>
+      <gmd:referenceSystemIdentifier>
+        <gmd:RS_Identifier>
+          <gmd:code>
+            <gmx:Anchor xmlns:gmx="http://www.isotc211.org/2005/gmx" xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="https://www.opengis.net/def/crs/EPSG/0/3857">WGS84 / Pseudo-Mercator</gmx:Anchor>
+          </gmd:code>
+        </gmd:RS_Identifier>
+      </gmd:referenceSystemIdentifier>
+    </gmd:MD_ReferenceSystem>
+  </gmd:referenceSystemInfo>
+  <gmd:referenceSystemInfo>
+    <gmd:MD_ReferenceSystem>
+      <gmd:referenceSystemIdentifier>
+        <gmd:RS_Identifier>
+          <gmd:code>
+            <gmx:Anchor xlink:href="http://www.opengis.net/def/crs/EPSG/0/4258">ETRS89</gmx:Anchor>
+          </gmd:code>
+        </gmd:RS_Identifier>
+      </gmd:referenceSystemIdentifier>
+    </gmd:MD_ReferenceSystem>
+  </gmd:referenceSystemInfo>
   <gmd:identificationInfo>
     <srv:SV_ServiceIdentification>
       <gmd:citation>

--- a/pkg/generator/iso19119/testdata/expected/inspire_hvd_complex_wfs_interoperable.xml
+++ b/pkg/generator/iso19119/testdata/expected/inspire_hvd_complex_wfs_interoperable.xml
@@ -51,6 +51,50 @@
   <gmd:metadataStandardVersion>
     <gco:CharacterString>Nederlands metadata profiel op ISO 19119 voor services 2.1.0</gco:CharacterString>
   </gmd:metadataStandardVersion>
+  <gmd:referenceSystemInfo>
+    <gmd:MD_ReferenceSystem>
+      <gmd:referenceSystemIdentifier>
+        <gmd:RS_Identifier>
+          <gmd:code>
+            <gmx:Anchor xmlns:gmx="http://www.isotc211.org/2005/gmx" xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="https://www.opengis.net/def/crs/EPSG/0/4326">WGS84</gmx:Anchor>
+          </gmd:code>
+        </gmd:RS_Identifier>
+      </gmd:referenceSystemIdentifier>
+    </gmd:MD_ReferenceSystem>
+  </gmd:referenceSystemInfo>
+  <gmd:referenceSystemInfo>
+    <gmd:MD_ReferenceSystem>
+      <gmd:referenceSystemIdentifier>
+        <gmd:RS_Identifier>
+          <gmd:code>
+            <gmx:Anchor xmlns:gmx="http://www.isotc211.org/2005/gmx" xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://www.opengis.net/def/crs/EPSG/0/28992">Amersfoort / RD New</gmx:Anchor>
+          </gmd:code>
+        </gmd:RS_Identifier>
+      </gmd:referenceSystemIdentifier>
+    </gmd:MD_ReferenceSystem>
+  </gmd:referenceSystemInfo>
+  <gmd:referenceSystemInfo>
+    <gmd:MD_ReferenceSystem>
+      <gmd:referenceSystemIdentifier>
+        <gmd:RS_Identifier>
+          <gmd:code>
+            <gmx:Anchor xmlns:gmx="http://www.isotc211.org/2005/gmx" xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="https://www.opengis.net/def/crs/EPSG/0/3857">WGS84 / Pseudo-Mercator</gmx:Anchor>
+          </gmd:code>
+        </gmd:RS_Identifier>
+      </gmd:referenceSystemIdentifier>
+    </gmd:MD_ReferenceSystem>
+  </gmd:referenceSystemInfo>
+  <gmd:referenceSystemInfo>
+    <gmd:MD_ReferenceSystem>
+      <gmd:referenceSystemIdentifier>
+        <gmd:RS_Identifier>
+          <gmd:code>
+            <gmx:Anchor xlink:href="http://www.opengis.net/def/crs/EPSG/0/4258">ETRS89</gmx:Anchor>
+          </gmd:code>
+        </gmd:RS_Identifier>
+      </gmd:referenceSystemIdentifier>
+    </gmd:MD_ReferenceSystem>
+  </gmd:referenceSystemInfo>
   <gmd:identificationInfo>
     <srv:SV_ServiceIdentification>
       <gmd:citation>

--- a/pkg/generator/iso19119/testdata/expected/inspire_hvd_complex_wfs_invocable.xml
+++ b/pkg/generator/iso19119/testdata/expected/inspire_hvd_complex_wfs_invocable.xml
@@ -51,6 +51,50 @@
   <gmd:metadataStandardVersion>
     <gco:CharacterString>Nederlands metadata profiel op ISO 19119 voor services 2.1.0</gco:CharacterString>
   </gmd:metadataStandardVersion>
+  <gmd:referenceSystemInfo>
+    <gmd:MD_ReferenceSystem>
+      <gmd:referenceSystemIdentifier>
+        <gmd:RS_Identifier>
+          <gmd:code>
+            <gmx:Anchor xmlns:gmx="http://www.isotc211.org/2005/gmx" xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="https://www.opengis.net/def/crs/EPSG/0/4326">WGS84</gmx:Anchor>
+          </gmd:code>
+        </gmd:RS_Identifier>
+      </gmd:referenceSystemIdentifier>
+    </gmd:MD_ReferenceSystem>
+  </gmd:referenceSystemInfo>
+  <gmd:referenceSystemInfo>
+    <gmd:MD_ReferenceSystem>
+      <gmd:referenceSystemIdentifier>
+        <gmd:RS_Identifier>
+          <gmd:code>
+            <gmx:Anchor xmlns:gmx="http://www.isotc211.org/2005/gmx" xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://www.opengis.net/def/crs/EPSG/0/28992">Amersfoort / RD New</gmx:Anchor>
+          </gmd:code>
+        </gmd:RS_Identifier>
+      </gmd:referenceSystemIdentifier>
+    </gmd:MD_ReferenceSystem>
+  </gmd:referenceSystemInfo>
+  <gmd:referenceSystemInfo>
+    <gmd:MD_ReferenceSystem>
+      <gmd:referenceSystemIdentifier>
+        <gmd:RS_Identifier>
+          <gmd:code>
+            <gmx:Anchor xmlns:gmx="http://www.isotc211.org/2005/gmx" xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="https://www.opengis.net/def/crs/EPSG/0/3857">WGS84 / Pseudo-Mercator</gmx:Anchor>
+          </gmd:code>
+        </gmd:RS_Identifier>
+      </gmd:referenceSystemIdentifier>
+    </gmd:MD_ReferenceSystem>
+  </gmd:referenceSystemInfo>
+  <gmd:referenceSystemInfo>
+    <gmd:MD_ReferenceSystem>
+      <gmd:referenceSystemIdentifier>
+        <gmd:RS_Identifier>
+          <gmd:code>
+            <gmx:Anchor xlink:href="http://www.opengis.net/def/crs/EPSG/0/4258">ETRS89</gmx:Anchor>
+          </gmd:code>
+        </gmd:RS_Identifier>
+      </gmd:referenceSystemIdentifier>
+    </gmd:MD_ReferenceSystem>
+  </gmd:referenceSystemInfo>
   <gmd:identificationInfo>
     <srv:SV_ServiceIdentification>
       <gmd:citation>

--- a/pkg/generator/iso19119/testdata/input/inspire_harmonised.yaml
+++ b/pkg/generator/iso19119/testdata/input/inspire_harmonised.yaml
@@ -34,6 +34,11 @@ services:
   - type: wfs
     id: "00000000-0000-0000-0000-000000000011"
     accessPoint: "https://test.nl/test/wfs?request=GetCapabilities&service=WFS"
+    referenceSystemIdentifiers:
+      - "EPSG:4326"
+      - "EPSG:28992"
+      - "EPSG:3857"
+      - "EPSG:4258"
   - type: atom
     id: "00000000-0000-0000-0000-000000000012"
     accessPoint: "https://test.nl/test/atom/index.xml"

--- a/pkg/generator/iso19119/testdata/input/inspire_hvd_complex.yaml
+++ b/pkg/generator/iso19119/testdata/input/inspire_hvd_complex.yaml
@@ -50,11 +50,26 @@ services:
     id: "00000000-0000-0000-0000-000000000014"
     accessPoint: "https://test.nl/test-invocable/wfs?request=GetCapabilities&service=WFS"
     serviceInspireType: "invocable"
+    referenceSystemIdentifiers:
+      - "EPSG:4326"
+      - "EPSG:28992"
+      - "EPSG:3857"
+      - "EPSG:4258"
   - type: wfs
     id: "00000000-0000-0000-0000-000000000015"
     accessPoint: "https://test.nl/test-interoperable/wfs?request=GetCapabilities&service=WFS"
     serviceInspireType: "interoperable"
+    referenceSystemIdentifiers:
+      - "EPSG:4326"
+      - "EPSG:28992"
+      - "EPSG:3857"
+      - "EPSG:4258"
   - type: oaf
     id: "00000000-0000-0000-0000-000000000016"
     accessPoint: "https://test.nl/test-interoperable/ogc/v1"
     serviceInspireType: "interoperable"
+    referenceSystemIdentifiers:
+      - "EPSG:4326"
+      - "EPSG:28992"
+      - "EPSG:3857"
+      - "EPSG:4258"

--- a/pkg/generator/iso19119/testdata/input/invalid_inspire_sds_without_referencesystem.yaml
+++ b/pkg/generator/iso19119/testdata/input/invalid_inspire_sds_without_referencesystem.yaml
@@ -6,16 +6,13 @@ globals:
   qosAvailability: 99.999
   qosPerformance: 1
   qosCapacity: 100
-  title: "Test inspire"
-  creationDate: "2018-08-16"
+  title: "Test regular"
+  creationDate: "2019-09-26"
   revisionDate: "2025-01-09"
-  abstract: "Unit test inspire"
+  abstract: "Unit test regular"
   keywords:
-    - "A"
-    - "B"
-    - "C"
-  inspireThemes:
-    - "ps"
+    - "AA"
+    - "BB"
   serviceLicense: "https://creativecommons.org/licenses/by/4.0/deed.nl"
   useLimitation: "Geen beperkingen"
   boundingBox:
@@ -24,21 +21,20 @@ globals:
     minY: "50.733607"
     maxY: "53.582979"
   linkedDatasets:
-    - "40000000-0000-0000-0000-000000000000"
+    - "00000000-0000-0000-0000-000000000003"
   coordinateReferenceSystem: "EPSG:28992"
-  inspireDatasetType: "asis"
+  thumbnails:
+    - file: "https://test.nl/thumb.png"
+      description: "thumbnail"
+      filetype: "png"
+  inspireDatasetType: "harmonised"
+  inspireThemes:
+    - "ps"
 services:
-  - type: wms
-    id: "00000000-0000-0000-0000-000000000007"
-    accessPoint: "https://test.nl/test/wms?request=GetCapabilities&service=WMS"
   - type: wfs
-    id: "00000000-0000-0000-0000-000000000008"
+    id: "00000000-0000-0000-0000-000000000001"
     accessPoint: "https://test.nl/test/wfs?request=GetCapabilities&service=WFS"
-    referenceSystemIdentifiers:
-      - "EPSG:4326"
-      - "EPSG:28992"
-      - "EPSG:3857"
-      - "EPSG:4258"
-  - type: atom
-    id: "00000000-0000-0000-0000-000000000009"
-    accessPoint: "https://test.nl/test/atom/index.xml"
+    keywords:
+      - "AA"
+      - "BB"
+      - "CCC"

--- a/pkg/generator/iso19119/testdata/input/invalid_inspire_type_no_themes.yaml
+++ b/pkg/generator/iso19119/testdata/input/invalid_inspire_type_no_themes.yaml
@@ -31,7 +31,7 @@ services:
   - type: wfs
     id: "00000000-0000-0000-0000-000000000001"
     accessPoint: "https://test.nl/test/wfs?request=GetCapabilities&service=WFS"
-    serviceInspireType: "networkservice"
+    serviceInspireType: "invocable"
     keywords:
       - "AA"
       - "BB"

--- a/pkg/model/codelist/codelists.json
+++ b/pkg/model/codelist/codelists.json
@@ -23,6 +23,18 @@
      "EPSG:4326": {
       "name": "WGS84",
       "uri": "https://www.opengis.net/def/crs/EPSG/0/4326"
+    },
+    "EPSG:3857": {
+      "name": "WGS84 / Pseudo-Mercator",
+      "uri": "https://www.opengis.net/def/crs/EPSG/0/3857"
+    },
+    "EPSG:25831": {
+      "name": "ETRS89 / UTM zone 31N",
+      "uri": "http://www.opengis.net/def/crs/EPSG/0/25831"
+    },
+    "EPSG:25832": {
+      "name": "ETRS89 / UTM zone 32N",
+      "uri": "http://www.opengis.net/def/crs/EPSG/0/25832"
     }
   },
   "inspireThemes": {

--- a/pkg/model/iso1911x/ISO19119.go
+++ b/pkg/model/iso1911x/ISO19119.go
@@ -26,9 +26,10 @@ type ISO19119 struct {
 	HierarchyLevelName CharacterStringTag `xml:"gmd:hierarchyLevelName"`
 	Contact            ContactTag         `xml:"gmd:contact"`
 
-	DateStamp               DateTag            `xml:"gmd:dateStamp"`
-	MetadataStandardName    CharacterStringTag `xml:"gmd:metadataStandardName"`
-	MetadataStandardVersion CharacterStringTag `xml:"gmd:metadataStandardVersion"`
+	DateStamp               DateTag               `xml:"gmd:dateStamp"`
+	MetadataStandardName    CharacterStringTag    `xml:"gmd:metadataStandardName"`
+	MetadataStandardVersion CharacterStringTag    `xml:"gmd:metadataStandardVersion"`
+	ReferenceSystemInfos    []ReferenceSystemInfo `xml:"gmd:referenceSystemInfo"`
 
 	IdentificationInfo IdentificationInfo `xml:"gmd:identificationInfo"`
 	DistributionInfo   DistributionInfo   `xml:"gmd:distributionInfo"`
@@ -143,6 +144,31 @@ type KeywordTag struct {
 // KeywordTypeTag struct for XML marshalling.
 type KeywordTypeTag struct {
 	Code CodeListValueTag `xml:"gmd:MD_KeywordTypeCode"`
+}
+
+// ReferenceSystemInfo struct for XML marshalling.
+type ReferenceSystemInfo struct {
+	MDReferenceSystem MDReferenceSystem `xml:"gmd:MD_ReferenceSystem"`
+}
+
+// MDReferenceSystem struct for XML marshalling.
+type MDReferenceSystem struct {
+	ReferenceSystemIdentifier ReferenceSystemIdentifier `xml:"gmd:referenceSystemIdentifier"`
+}
+
+// ReferenceSystemIdentifier struct for XML marshalling.
+type ReferenceSystemIdentifier struct {
+	RSIdentifier RSIdentifier `xml:"gmd:RS_Identifier"`
+}
+
+// RSIdentifier struct for XML marshalling.
+type RSIdentifier struct {
+	Code Code `xml:"gmd:code"`
+}
+
+// Code struct for XML marshalling.
+type Code struct {
+	Anchor AnchorTag `xml:"gmx:Anchor"`
 }
 
 // IdentificationInfo struct for XML marshalling.


### PR DESCRIPTION
# Description

- Added `referenceSystemInfo` to ISO19119 metadata generation for INSPIRE SDS

## Type of change


- Improvement of existing feature

# Checklist:

- [x] I've double-checked the code in this PR myself
- [ ] I've left the code better than before ([boy scout rule](https://wiki.c2.com/?BoyScoutRule))
- [x] The code is readable, comments are added that explain hard or non-obvious parts.
- [x] I've expanded/improved the (unit) tests, when applicable
- [x] I've run (unit) tests that prove my solution works
- [x] There's no sensitive information like credentials in my PR